### PR TITLE
Add CSRF protection to Flask application

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -11,6 +11,7 @@ import pickle
 from werkzeug.utils import secure_filename
 from markupsafe import Markup
 import subprocess
+from flask_wtf.csrf import CSRFProtect
 
 
 Base = declarative_base()
@@ -25,6 +26,8 @@ class Product(Base):
     image = Column(String)
 
 app = Flask(__name__)
+app.config['SECRET_KEY'] = 'dev-secret-key-change-in-production'
+csrf = CSRFProtect(app)
 
 engine = create_engine('sqlite:///products.db', connect_args={'check_same_thread': False})
 Base.metadata.create_all(engine)


### PR DESCRIPTION
## Summary

This PR fixes 1 security vulnerability identified by BoostSecurity.

---

### Add CSRF protection to Flask application in `src/app.py` (Line: 63)

**Risk:** The Flask application accepted state-changing POST requests without CSRF protection, allowing malicious sites to trick authenticated users into performing unwanted actions like deleting products, updating product data, uploading files, or searching.

**Fix:** Enabled Flask-WTF's CSRFProtect for the entire application, which automatically validates CSRF tokens on all POST requests. Added a SECRET_KEY configuration required for CSRF token generation.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*