### PR TITLE
Enable CSRF protection for Flask application

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -11,6 +11,7 @@ import pickle
 from werkzeug.utils import secure_filename
 from markupsafe import Markup
 import subprocess
+from flask_wtf.csrf import CSRFProtect
 
 
 Base = declarative_base()
@@ -25,6 +26,8 @@ class Product(Base):
     image = Column(String)
 
 app = Flask(__name__)
+app.config['SECRET_KEY'] = 'your-secret-key-here'  # Change this to a secure random key in production
+csrf = CSRFProtect(app)
 
 engine = create_engine('sqlite:///products.db', connect_args={'check_same_thread': False})
 Base.metadata.create_all(engine)


### PR DESCRIPTION
## Summary

This PR fixes 1 security vulnerability identified by BoostSecurity.

---

### Add CSRF protection to Flask application in `src/app.py` (Line: 107)

**Risk:** Flask routes accepting POST requests (delete_product, upload_file, update_product, search) were vulnerable to Cross-Site Request Forgery attacks. Attackers could trick authenticated users into performing unwanted state-changing actions by making malicious requests from external sites.

**Fix:** Enabled Flask-WTF's CSRFProtect globally for the application by importing CSRFProtect, initializing it with the Flask app instance, and adding a SECRET_KEY configuration. This provides automatic CSRF token validation for all POST requests.

**Review notes:** Templates rendering forms will need to include CSRF tokens using `{{ csrf_token() }}` or the form will be rejected by the protection.

---

*Generated by [BoostSecurity Advisor](https://boostsecurity.io)*